### PR TITLE
Support OSX Notifications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ notification run this command::
 
     $ unpushed-notify ~
 
-On Linux this is done through pynotify library. On other systems this feature is
+On Linux this is done through pynotify library. On OS X through pyobjc. On other systems this feature is
 not implemented yet.
 
 You can add this line to your crontab (*crontab -e*)::


### PR DESCRIPTION
Fixes #11. Depends on PyObjC. 

Slightly refactored how the notifications are passed to their respective OS. Notifications in OS X have to be kept fairly terse otherwise they're pretty useless. 